### PR TITLE
Cambios en exists_G

### DIFF
--- a/Leantest/BasicProp/closure.lean
+++ b/Leantest/BasicProp/closure.lean
@@ -96,6 +96,14 @@ lemma closure_is_closed {X : Type} [T : TopologicalSpace X] (A : Set X) :
   exact interior_is_open Aᶜ
 
 
+lemma closure_of_empty {X : Type} [T : TopologicalSpace X] : Closure (∅ : Set X) = ∅ := by
+  simp [Closure]
+  ext x
+  simp
+  use Set.univ
+  exact univ_is_Neighb x
+
+
 
 def Boundary {X : Type} [T : TopologicalSpace X] (A : Set X) : Set X :=
     {x : X | ∀ V : Set X, Neighbourhood V x → V ∩ A ≠ ∅ ∧ V ∩ Aᶜ ≠ ∅}

--- a/Leantest/Separation/nuevaidea.lean
+++ b/Leantest/Separation/nuevaidea.lean
@@ -645,36 +645,44 @@ lemma prop1 {X : Type} [T : TopologicalSpace X]
   have cases : p < 0 ∨ 0 ≤ p := by exact lt_or_le p 0
   cases' cases with hp hp
 
-  · simp [G, hp]
+  · -- caso p < 0
+    simp [G, hp]
 
-  · have cases : p ≤ 1 ∨ 1 < p := by exact le_or_lt p 1
+  · -- caso 0 ≤ p
+    have cases : p ≤ 1 ∨ 1 < p := by exact le_or_lt p 1
     cases' cases with hp' hp
 
-    · have aux : ¬ p < 0
+    · -- caso 0 ≤ p ≤ 1
+      have aux : ¬ p < 0
       · linarith
       have hp : 0 ≤ p ∧ p ≤ 1
       · constructor; exact hp; exact hp'
 
       simp [G, aux, hp]
 
-      have aux : ¬ (f_inv ⟨p, hp⟩ = 0)
-      · sorry
-      have aux' : ¬ (f_inv ⟨p, hp⟩ = 1)
-      · sorry
-      simp [G']
-      have cases : 1 < f_inv ⟨p, hp⟩ ∨ ¬ ( 1 < f_inv ⟨p, hp⟩)
-      · exact Decidable.em (1 < f_inv ⟨p, hp⟩)
+      cases' (f_inv ⟨p, hp⟩) with k
+      · simp [G']
+        exact { isOpen_compl := hC2 }
 
-      cases' cases with aux'' aux''
+      · cases' k with k
+        · simp [G']
+          let h := Classical.choose_spec (hT' C2ᶜ C1 hC2 hC1 hC1C2)
+          exact h.left
 
-      · simp [G', aux, aux', aux'']
-        simp [Gn]
-        let hGn := Classical.choose_spec (exists_G hT C1 C2 hC1 hC2 hC1C2 (f_inv ⟨p, hp⟩) aux'')
-        let hGn := hGn.left
-        specialize hGn (f_inv ⟨p, hp⟩) (by exact Nat.le_refl (f_inv ⟨p, hp⟩))
-        exact hGn
+        · simp [G']
+          simp [Gn]
+          let h := Classical.choose_spec (exists_G hT C1 C2 hC1 hC2 hC1C2 (k + 1 + 1) (by linarith))
+          let h := h.left
+          exact h (k + 1 + 1) (by linarith)
 
-      · simp [G', aux, aux', aux'']
+    · -- caso 1 < p
+      have aux : ¬ p < 0
+      · linarith
+      have aux' : ¬ (0 ≤ p ∧ p ≤ 1)
+      · simp
+        intro
+        exact hp
+      simp [G, hp, aux, aux']
 
 
     · have aux : ¬ p < 0

--- a/Leantest/Separation/nuevaidea.lean
+++ b/Leantest/Separation/nuevaidea.lean
@@ -799,10 +799,17 @@ lemma prop2 {X : Type} [T : TopologicalSpace X]
           simp [hfp, hfq, auxq, auxq', G']
           simp [Gn]
           have h := (Classical.choose_spec (exists_G hT C1 C2 hC1 hC2 hC1C2 (f_inv ⟨q, hq⟩) hfq))
-          have h := h.right
-          specialize (h 1 (f_inv ⟨q, hq⟩) (by linarith) (by linarith) (by sorry))
+          have H := h.right.left
+          have h0 := h.right.right
 
-          have h' :
+          have aux : f 0 < f (f_inv ⟨q, hq⟩)
+          simp [f_prop.right.left, f_inv_prop.right]
+
+          sorry
+
+          specialize (H 0 (f_inv ⟨q, hq⟩) (by linarith) (by linarith) (by ))
+          rw [h0] at H
+          exact H
 
 
 

--- a/Leantest/Separation/nuevaidea.lean
+++ b/Leantest/Separation/nuevaidea.lean
@@ -580,6 +580,34 @@ noncomputable def Gn {X : Type} [T : TopologicalSpace X]
     := fun m ↦ (Classical.choose (exists_G hT C1 C2 hC1 hC2 hC1C2 n hn)) m
 
 
+
+lemma question {X : Type} [T : TopologicalSpace X]
+
+    (hT : NormalTopoSpace T)
+
+    (C1 C2 : Set X)
+    (hC1 : IsClosed C1)
+    (hC2 : IsOpen C2ᶜ)
+    (hC1C2 : C1 ⊆ C2ᶜ)
+
+    (n m : ℕ)
+    (hn : n > 1)
+    (hm : m > 1)
+    (h : n ≤ m)
+
+    :
+
+    (Gn hT C1 C2 hC1 hC2 hC1C2 n hn) n = (Gn hT C1 C2 hC1 hC2 hC1C2 m hm) n := by
+
+  simp [Gn]
+
+  have h1 := Classical.choose_spec (exists_G hT C1 C2 hC1 hC2 hC1C2 n hn)
+  have h2 := Classical.choose_spec (exists_G hT C1 C2 hC1 hC2 hC1C2 m hm)
+
+  sorry
+
+
+
 def G' {X : Type} [T : TopologicalSpace X]
     (hT : NormalTopoSpace T)
     (hT' : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
@@ -714,19 +742,15 @@ lemma prop2 {X : Type} [T : TopologicalSpace X]
   /-
   se divide en varios casos.
 
-  1. si `p, q < 0`, entonces el goal se traduce a `∅ ⊆ ∅`
-
-  2. si `p < 0, 0 ≤ q`, entonces el goal se traduce a `∅ ⊆ U`,
+  1. si `p < 0`, entonces el goal se traduce a `∅ ⊆ U`,
     que es cierto para todo U
 
-  3. si `0 ≤ p, q ≤ 1`
-    - llamamos `n = f⁻¹(p)` y `m = f⁻¹(q)`
-    - dividimos en casos de valores de n y m...
-
-  4. si `q > 1`, entonces el goal se traduce a `U ⊆ Set.univ`,
+  2.  si `q > 1`, entonces el goal se traduce a `U ⊆ Set.univ`,
     que es cierto para todo U
 
-  Luego realmente hay que dividir por casos en q
+  3. en caso contrario, si `0 ≤ p` y `q ≤ 1`, puesto que
+    `p < q` se tiene `p, q ∈ Q`, luego podemos aplicar
+    la inversa de `f` y la definición de `Gn`
   -/
 
   have cases : q < 0 ∨ 0 ≤ q := by exact lt_or_le q 0

--- a/Leantest/Separation/nuevaidea.lean
+++ b/Leantest/Separation/nuevaidea.lean
@@ -231,7 +231,7 @@ RESULTADO PRINCIPAL:
 
 
 lemma exists_G {X : Type} [T : TopologicalSpace X]
-    (hT : NormalTopoSpace T)
+    (hT : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
 
     (C1 C2 : Set X)
     (hC1 : IsClosed C1)
@@ -248,10 +248,10 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
         (∀ p q : ℕ, p ≤ n → q ≤ n → f p < f q → Closure (G p) ⊆ G q)
         ∧
         (G 0 = C2ᶜ)
+        ∧
+        (G 1 = Classical.choose (hT C2ᶜ C1 hC2 hC1 hC1C2))
         )
     := by
-
-  rw [characterization_of_normal] at hT
 
   induction' hn with n hn HI
 
@@ -367,7 +367,12 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
         rw [f_prop.right.left] at hpq
         exact Std.Tactic.BVDecide.Reflect.Bool.false_of_eq_true_of_eq_false hpq (f q).property.right
 
+    constructor
+
     · -- PROP 3
+      simp [G]
+
+    · -- PROP 4
       simp [G]
 
 
@@ -560,9 +565,17 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
           · exact Nat.le_of_lt_succ hq
           · exact hpq
 
+    constructor
+
     · -- PROP 3
       simp [G]
-      exact hG'.right.right
+      exact hG'.right.right.left
+
+    · -- PROP 4
+      have aux : n > 0 := by linarith
+      simp [G, aux]
+      exact hG'.right.right.right
+
 
 
 noncomputable def Gn {X : Type} [T : TopologicalSpace X]

--- a/Leantest/Separation/nuevaidea.lean
+++ b/Leantest/Separation/nuevaidea.lean
@@ -246,6 +246,8 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
         (∀ p : ℕ, p ≤ n → IsOpen (G p))
         ∧
         (∀ p q : ℕ, p ≤ n → q ≤ n → f p < f q → Closure (G p) ⊆ G q)
+        ∧
+        (G 0 = C2ᶜ)
         )
     := by
 
@@ -297,6 +299,7 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
         simp [hp, G]
         exact { isOpen_compl := hC2 }
 
+    constructor
 
     · -- PROP 2
       intro p q hp hq hpq
@@ -364,6 +367,9 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
         rw [f_prop.right.left] at hpq
         exact Std.Tactic.BVDecide.Reflect.Bool.false_of_eq_true_of_eq_false hpq (f q).property.right
 
+    · -- PROP 3
+      simp [G]
+
 
   · -- caso recursivo
 
@@ -391,7 +397,7 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
       exact hs
 
     have hGrs : Closure (G' r) ⊆ G' s
-    · apply hG'.right
+    · apply hG'.right.left
       · exact hr
       · exact hs
       · trans f (n + 1)
@@ -439,6 +445,8 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
         apply hG'.left
         exact Nat.le_of_lt_succ hp
 
+    constructor
+
     · -- PROP 2
       intro p q hp hq hpq
 
@@ -481,7 +489,7 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
 
               · apply set_inside_closure
 
-              · apply hG'.right
+              · apply hG'.right.left
                 · exact hs
                 · exact Nat.le_of_lt_succ hq
                 · apply lt_of_le_of_ne
@@ -524,7 +532,7 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
 
             · trans (G' r)
 
-              · apply hG'.right
+              · apply hG'.right.left
                 · exact Nat.le_of_lt_succ hp
                 · exact hr
                 · apply lt_of_le_of_ne
@@ -547,10 +555,14 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
           simp at hq
           rw [← Order.lt_add_one_iff] at hp hq
           simp [hp, hq, G]
-          apply hG'.right
+          apply hG'.right.left
           · exact Nat.le_of_lt_succ hp
           · exact Nat.le_of_lt_succ hq
           · exact hpq
+
+    · -- PROP 3
+      simp [G]
+      exact hG'.right.right
 
 
 noncomputable def Gn {X : Type} [T : TopologicalSpace X]

--- a/Leantest/Separation/nuevaidea.lean
+++ b/Leantest/Separation/nuevaidea.lean
@@ -580,7 +580,7 @@ lemma exists_G {X : Type} [T : TopologicalSpace X]
 
 noncomputable def Gn {X : Type} [T : TopologicalSpace X]
 
-    (hT : NormalTopoSpace T)
+    (hT : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
 
     (C1 C2 : Set X)
     (hC1 : IsClosed C1)
@@ -596,7 +596,7 @@ noncomputable def Gn {X : Type} [T : TopologicalSpace X]
 
 lemma question {X : Type} [T : TopologicalSpace X]
 
-    (hT : NormalTopoSpace T)
+    (hT : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
 
     (C1 C2 : Set X)
     (hC1 : IsClosed C1)
@@ -622,8 +622,7 @@ lemma question {X : Type} [T : TopologicalSpace X]
 
 
 def G' {X : Type} [T : TopologicalSpace X]
-    (hT : NormalTopoSpace T)
-    (hT' : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
+    (hT : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
 
     (C1 C2 : Set X)
     (hC1 : IsClosed C1)
@@ -635,7 +634,7 @@ def G' {X : Type} [T : TopologicalSpace X]
     := fun n ↦
 
   if n = 0 then C2ᶜ
-  else if n = 1 then Classical.choose (hT' C2ᶜ C1 hC2 hC1 hC1C2)
+  else if n = 1 then Classical.choose (hT C2ᶜ C1 hC2 hC1 hC1C2)
   else if h : n > 1 then ((Gn hT C1 C2 hC1 hC2 hC1C2 n h) n)
   else ∅
 
@@ -665,8 +664,7 @@ DEFINICIÓN DE LA G FINAL
 -/
 
 def G {X : Type} [T : TopologicalSpace X]
-    (hT : NormalTopoSpace T)
-    (hT' : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
+    (hT : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
 
     (C1 C2 : Set X)
     (hC1 : IsClosed C1)
@@ -676,7 +674,7 @@ def G {X : Type} [T : TopologicalSpace X]
     : ℚ → Set X := fun q ↦
 
   if q < 0 then ∅
-  else if h : (0 ≤ q ∧ q ≤ 1) then (G' hT hT' C1 C2 hC1 hC2 hC1C2 (f_inv ⟨q, h⟩))
+  else if h : (0 ≤ q ∧ q ≤ 1) then (G' hT C1 C2 hC1 hC2 hC1C2 (f_inv ⟨q, h⟩))
   else Set.univ
 
 
@@ -685,15 +683,14 @@ CUMPLE LAS PROPIEDADES???
 -/
 
 lemma prop1 {X : Type} [T : TopologicalSpace X]
-    (hT : NormalTopoSpace T)
-    (hT' : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
+    (hT : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
 
     (C1 C2 : Set X)
     (hC1 : IsClosed C1)
     (hC2 : IsOpen C2ᶜ)
     (hC1C2 : C1 ⊆ C2ᶜ)
 
-    : ∀ p : ℚ, IsOpen (G hT hT' C1 C2 hC1 hC2 hC1C2 p) := by
+    : ∀ p : ℚ, IsOpen (G hT C1 C2 hC1 hC2 hC1C2 p) := by
 
   intro p
 
@@ -721,7 +718,7 @@ lemma prop1 {X : Type} [T : TopologicalSpace X]
 
       · cases' k with k
         · simp [G']
-          let h := Classical.choose_spec (hT' C2ᶜ C1 hC2 hC1 hC1C2)
+          let h := Classical.choose_spec (hT C2ᶜ C1 hC2 hC1 hC1C2)
           exact h.left
 
         · simp [G']
@@ -740,15 +737,14 @@ lemma prop1 {X : Type} [T : TopologicalSpace X]
       simp [G, hp, aux, aux']
 
 lemma prop2 {X : Type} [T : TopologicalSpace X]
-    (hT : NormalTopoSpace T)
-    (hT' : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
+    (hT : ∀ (U C : Set X), IsOpen U → IsClosed C → C ⊆ U → ∃ V, IsOpen V ∧ C ⊆ V ∧ Closure V ⊆ U)
 
     (C1 C2 : Set X)
     (hC1 : IsClosed C1)
     (hC2 : IsOpen C2ᶜ)
     (hC1C2 : C1 ⊆ C2ᶜ)
 
-    : ∀ p q: ℚ, p < q → Closure (G hT hT' C1 C2 hC1 hC2 hC1C2 p) ⊆ G hT hT' C1 C2 hC1 hC2 hC1C2 q := by
+    : ∀ p q: ℚ, p < q → Closure (G hT C1 C2 hC1 hC2 hC1C2 p) ⊆ G hT C1 C2 hC1 hC2 hC1C2 q := by
 
   intro p q hpq
 


### PR DESCRIPTION
Añade al lemma exists_G las condiciones de que los valores G(0) y G(1) sean unos abiertos concretos (con demostración).
Se terminan los detalles de la demostración de que todo G(n) es abierto.
Sin embargo, la propiedad 2 (∀ p q: ℚ, p < q → Closure (G p) ⊆ G  q) no queda demostrada y de hecho parece que no se puede demostrar con esta definición de G: ahora mismo la definición de G(n) para cada n no tiene en cuenta los m < n anteriores, por tanto no se puede afirmar que G(m) para un cierto m sea igual a G_n(m) para un n>m.